### PR TITLE
upgrader: change to module-aware engine

### DIFF
--- a/invenio/modules/upgrader/manage.py
+++ b/invenio/modules/upgrader/manage.py
@@ -58,7 +58,8 @@ def applied():
     """
     Command for showing all upgrades already applied.
     """
-    from invenio.modules.upgrader.engine import cmd_upgrade_show_applied
+    from invenio.modules.upgrader.engine import \
+        cmd_upgrade_show_applied
     cmd_upgrade_show_applied()
 
 
@@ -72,21 +73,34 @@ def release(path, repository):
     """
     Create a new release upgrade recipe (for developers).
     """
-    from invenio.modules.upgrader.engine import cmd_upgrade_create_release_recipe
+    from invenio.modules.upgrader.engine import \
+        cmd_upgrade_create_release_recipe
     cmd_upgrade_create_release_recipe(path, repository)
 
 
-@create.option('-p', '--path', dest='path')
-@create.option('-r', '--repository', dest='repository', default='invenio')
-@create.option('-d', '--depends_on', dest='depends_on')
+@create.option('-p', '--package', dest='package', required=True,
+               help="Import path of module where to create recipe (required).")
+@create.option('-o', '--path', dest='output_path',
+               help="Override output path.")
+@create.option('-r', '--repository', dest='repository',
+               help="Override repository name")
+@create.option('-d', '--depends_on', dest='depends_on',
+               help="List of recipes to depend on.")
 @create.option('--release', dest='release', action='store_true')
-def recipe(path, repository, depends_on=None, release=False):
+def recipe(package, repository=None, depends_on=None, release=False,
+           output_path=None):
     """
     Create a new upgrade recipe (for developers).
     """
-    from invenio.modules.upgrader.engine import cmd_upgrade_create_standard_recipe
-    cmd_upgrade_create_standard_recipe(path, repository, depends_on=depends_on,
-                                       release=release)
+    from invenio.modules.upgrader.engine import \
+        cmd_upgrade_create_standard_recipe
+    cmd_upgrade_create_standard_recipe(
+        package,
+        depends_on=depends_on,
+        repository=repository,
+        release=release,
+        output_path=output_path,
+    )
 
 
 def main():

--- a/invenio/modules/upgrader/testsuite/test_upgrader.py
+++ b/invenio/modules/upgrader/testsuite/test_upgrader.py
@@ -20,6 +20,15 @@
 """ Test unit for the miscutil/lib/inveniocfg_upgrader module. """
 
 
+from datetime import date
+import os
+import os.path
+import shutil
+import sys
+import tempfile
+
+import six
+
 from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
 
 
@@ -140,11 +149,13 @@ class TestInvenioUpgraderOrdering(InvenioTestCase):
             TestUpgrade('3', ['1', 'b'], 'invenio'),
             TestUpgrade('a', [], 'other'),
             TestUpgrade('b', ['a'], 'other'),
-            TestUpgrade('c', ['a'], 'other'),
+            TestUpgrade('c', ['2'], 'other'),
         ])
 
         m = InvenioUpgrader()
-        self.assertRaises(StandardError, m.order_upgrades, upgrades)
+        #self.assertRaises(StandardError, m.order_upgrades, upgrades)
+        self.assertEqual(upgrades_str(m.order_upgrades(upgrades)),
+                         "[1, 2, c, a, b, 3]")
 
     def test_history(self):
         """
@@ -171,7 +182,164 @@ class TestInvenioUpgraderOrdering(InvenioTestCase):
             upgrades_str(m.order_upgrades(upgrades, history)), "[6]")
 
 
-TEST_SUITE = make_test_suite(TestInvenioUpgraderOrdering,)
+class TestInvenioUpgraderRecipe(InvenioTestCase):
+    def setUp(self):
+        """
+        Setup a test python package, to test upgrade recipe creation.
+        """
+        self.tmpdir = tempfile.mkdtemp()
+        self.pkg_path = os.path.join(self.tmpdir, 'invenio_upgrader_test')
+        os.makedirs(self.pkg_path)
+        open(os.path.join(self.pkg_path, '__init__.py'), 'a').close()
+        self.pkg_path_mymod = os.path.join(
+            self.tmpdir, 'invenio_upgrader_test/mymod'
+        )
+        os.makedirs(self.pkg_path_mymod)
+
+        open(os.path.join(self.pkg_path, '__init__.py'), 'a').close()
+        open(os.path.join(self.pkg_path_mymod, '__init__.py'), 'a').close()
+
+        sys.path.append(self.tmpdir)
+        import invenio_upgrader_test
+        import invenio_upgrader_test.mymod
+
+    def tearDown(self):
+        """ Remove test package again """
+        sys.path.remove(self.tmpdir)
+        keys = []
+        for m in sys.modules:
+            if m.startswith('invenio_upgrader_test'):
+                keys.append(m)
+        for k in keys:
+            del sys.modules[k]
+
+        try:
+            import invenio_upgrader_test
+            raise AssertionError("Test package not removed from sys.path")
+        except ImportError:
+            pass
+
+        shutil.rmtree(self.tmpdir)
+
+    def test_create(self):
+        """ Test creation of upgrades """
+        from invenio.modules.upgrader.engine import \
+            cmd_upgrade_create_standard_recipe
+
+        cmd_upgrade_create_standard_recipe(
+            'invenio_upgrader_test.mymod',
+            depends_on=['test1', 'test2']
+        )
+
+        # Test if upgrade can be imported
+        expexted_name = "mymod_%s_rename_me" % \
+            date.today().strftime("%Y_%m_%d")
+
+        import invenio_upgrader_test.mymod.upgrades
+        upgrade = getattr(
+            __import__(
+                'invenio_upgrader_test.mymod.upgrades',
+                globals(), locals(), [expexted_name], -1
+            ),
+            expexted_name
+        )
+        # Test API of created upgrade recipe
+        assert upgrade.depends_on == ['test1', 'test2']
+        assert upgrade.estimate() == 1
+        assert isinstance(upgrade.info(), six.string_types)
+        upgrade.pre_upgrade()
+        upgrade.do_upgrade()
+        upgrade.post_upgrade()
+
+    def test_create_load_engine(self):
+        """ Test creation and loading of upgrades with engine """
+        from invenio.modules.upgrader.engine import \
+            cmd_upgrade_create_standard_recipe
+
+        cmd_upgrade_create_standard_recipe(
+            'invenio_upgrader_test',
+            depends_on=[]
+        )
+
+        expexted_name = "invenio_upgrader_test_%s_rename_me" % \
+            date.today().strftime("%Y_%m_%d")
+
+        # Test if upgrade can be found from the Upgrade
+        from invenio.modules.upgrader.engine import InvenioUpgrader
+        eng = InvenioUpgrader(packages=['invenio_upgrader_test'])
+        upgrades = eng.get_upgrades(remove_applied=False)
+        assert len(upgrades) == 1
+        assert upgrades[0]['id'] == expexted_name
+        assert upgrades[0]['repository'] == 'invenio_upgrader_test'
+
+    def test_double_create(self):
+        """ Test creation of upgrades """
+        from invenio.modules.upgrader.engine import \
+            cmd_upgrade_create_standard_recipe
+
+        cmd_upgrade_create_standard_recipe('invenio_upgrader_test')
+        # Second call fails since module already exists, and we didn't
+        # rename it yet.
+        self.assertRaises(
+            SystemExit,
+            cmd_upgrade_create_standard_recipe,
+            'invenio_upgrader_test',
+        )
+
+    def test_create_with_module(self):
+        from invenio.modules.upgrader.engine import \
+            cmd_upgrade_create_standard_recipe
+
+        # Module instead of package
+        self.assertRaises(
+            SystemExit,
+            cmd_upgrade_create_standard_recipe,
+            'invenio.modules.upgrader.engine'
+        )
+
+    def test_invalid_path(self):
+        """ Test creation of upgrades """
+        from invenio.modules.upgrader.engine import \
+            cmd_upgrade_create_standard_recipe
+
+        self.assertRaises(
+            SystemExit,
+            cmd_upgrade_create_standard_recipe,
+            'invenio_upgrader_test',
+            output_path=os.path.join(self.tmpdir, 'this_does_not_exists')
+        )
+
+    def test_create_release(self):
+        """ Test creation of upgrades """
+        from invenio.modules.upgrader.engine import InvenioUpgrader, \
+            cmd_upgrade_create_standard_recipe, \
+            cmd_upgrade_create_release_recipe
+
+        engine = InvenioUpgrader(packages=[
+            'invenio_upgrader_test', 'invenio_upgrader_test.mymod'])
+
+        cmd_upgrade_create_standard_recipe(
+            'invenio_upgrader_test', depends_on=[]
+        )
+        cmd_upgrade_create_standard_recipe(
+            'invenio_upgrader_test.mymod', depends_on=[]
+        )
+
+        cmd_upgrade_create_release_recipe(
+            'invenio_upgrader_test', repository='invenio', upgrader=engine
+        )
+
+        # Find all endpoints in all repositories
+        upgrades = engine.get_upgrades(remove_applied=False)
+        for u in upgrades:
+            if u['id'] == 'invenio_release_x_y_z':
+                assert len(u['depends_on']) == 2
+
+
+TEST_SUITE = make_test_suite(
+    TestInvenioUpgraderOrdering,
+    TestInvenioUpgraderRecipe,
+)
 
 if __name__ == "__main__":
     run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- Changes upgrader to load upgrades from all installed modules.
- Changes upgrade naming convention to be compatible with
  invenio modules.
- Changes upgrader to use SQLAlchemy models for querying
  instead of run_sql.
- Changes recipe creation to use module import paths as input
  instead of system paths.
- Relaxes constraint on cross-graph dependencies to allow
  inter-module dependencies.
- Removes pre-upgrade check for legacy custom templates.
- Adds tests of recipe creation.
- Fixes PEP8 issues.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
