### PR TITLE
RFC: JSON-LD

### DIFF
--- a/invenio/modules/jsonalchemy/jsonext/parsers/schema_parser.py
+++ b/invenio/modules/jsonalchemy/jsonext/parsers/schema_parser.py
@@ -19,8 +19,12 @@
 
 from pyparsing import QuotedString, Suppress, indentedBlock
 
+from invenio.base.utils import try_to_eval
+
 from invenio.modules.jsonalchemy.parser import BaseExtensionParser, \
         dict_def
+
+from ...registry import functions
 
 
 class SchemaParser(BaseExtensionParser):
@@ -38,7 +42,7 @@ class SchemaParser(BaseExtensionParser):
 
     @classmethod
     def create_element(cls, rule, override, extend, namespace):
-        return eval(rule.schema)
+        return try_to_eval(rule.schema, functions(namespace))
 
 SchemaParser.__name__ = 'schema'
 parser = SchemaParser

--- a/invenio/modules/jsonalchemy/registry.py
+++ b/invenio/modules/jsonalchemy/registry.py
@@ -68,3 +68,17 @@ readers_proxy = RegistryProxy('jsonext.readers',
 readers = LazyDict(lambda: dict((module.reader.__master_format__,
                                  module.reader)
                                 for module in readers_proxy))
+
+contexts_proxy = lambda namespace: RegistryProxy(
+    namespace + '.contexts', ModuleAutoDiscoverySubRegistry, 'contexts',
+    registry_namespace=jsonext(namespace))
+
+
+def contexts(namespace):
+    contexts = dict((module.__name__.split('.')[-1],
+                     getattr(module, 'context'))
+                    for module in contexts_proxy('jsonext'))
+    contexts.update((module.__name__.split('.')[-1],
+                     getattr(module, 'context'))
+                    for module in contexts_proxy(namespace))
+    return contexts

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ alembic==0.6.2
 git+https://github.com/lnielsen-cern/setuptools-bower.git#egg=setuptools-bower-0.1
 importlib==1.0.3
 pytz
+PyLD


### PR DESCRIPTION
Please let me know your thought on these JSON-LD exporter helpers. Some findings:
- We need to standardize on UTC.
- If you plan on exporting your model via JSON-LD it is better if you define it in a standard way (context, [example](http://www.openannotation.org/spec/core/publishing.html)) from the beginning; otherwise you will need to implement translations.
- We need to think of a way of specifying a default context for SmartJson models.
- It is quite tricky to send JSON search queries via plain GET, as we will receive all parameters as strings and thus we cannot take advantage of, for example, Mongo native types.
