### PR TITLE
logging: fix issue with db.func.now

### DIFF
--- a/invenio/ext/logging/models.py
+++ b/invenio/ext/logging/models.py
@@ -78,8 +78,8 @@ class HstEXCEPTION(db.Model):
             log = HstEXCEPTION(name=name,
                                filename=filename,
                                line=line,
-                               last_seen=db.func.now(),
-                               last_notified=db.func.now(),
+                               last_seen=datetime.now(),
+                               last_notified=datetime.now(),
                                counter=1,
                                total=1)
             db.session.add(log)


### PR DESCRIPTION
- Updates HstException with a fix to avoid an exception
  that was raised when exceptions are being stored into
  the HstException model.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
