### PR TITLE
celery: make Redis default broker

### DIFF
--- a/invenio/celery/config.py
+++ b/invenio/celery/config.py
@@ -24,7 +24,7 @@ def default_config(config):
     """
     ## Broker settings
     ## ---------------
-    config.setdefault("BROKER_URL", "amqp://guest:guest@localhost:5672//")
+    config.setdefault("BROKER_URL", "redis://localhost:6379/1")
 
     # Extra modules with tasks which should be loaded
     # The Invenio Celery loader automatically takes care of loading tasks
@@ -36,7 +36,7 @@ def default_config(config):
 
     ## Result backend
     ## --------------
-    config.setdefault("CELERY_RESULT_BACKEND", "amqp://guest:guest@localhost:5672//")
+    config.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
     config.setdefault("CELERY_RESULT_SERIALIZER", "msgpack")
 
     ## Routing


### PR DESCRIPTION
- Makes Redis the default broker for Celery.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
