### PR TITLE
installation: typeahead Grunt fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,10 +19,6 @@
 
 'use strict';
 
-/*jshint laxcomma:true */  // FIXME?
-
-/* global module */
-/* global require */
 
 module.exports = function (grunt) {
     var globalConfig = {

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -17,6 +17,11 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
  */
 
+'use strict';
+
+/*jshint laxcomma:true */  // FIXME?
+
+
 module.exports = {
     css: {
         expand: true,
@@ -73,8 +78,13 @@ module.exports = {
         expand: true,
         flatten: true,
         cwd: '<%= globalConfig.bower_path %>/',
-        src: ['typeahead.js/dist/typeahead.js'],
-        dest: '<%= globalConfig.installation_path %>/js/'
+        src: ['typeahead.js/dist/typeahead.bundle.min.js'],
+        dest: '<%= globalConfig.installation_path %>/js/',
+        rename: function(dest, src) {
+            var res = src.replace(src.substring(0),
+                                  'typeahead.js');
+            return dest + res;
+        }
     },
     typeaheadJSbootstrap: {
         expand: true,


### PR DESCRIPTION
- Fix typeahead path for v0.10+.
- Minor lint fixes.

Signed-off-by: Adrian-Tudor Panescu adrian.tudor.panescu@cern.ch
