### PR TITLE
base: fix config UTF-8 problems

### DIFF
--- a/invenio/base/config.py
+++ b/invenio/base/config.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2012, 2013 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import unicode_literals
+
 import distutils.sysconfig
 from os.path import join
 

--- a/invenio/base/helpers.py
+++ b/invenio/base/helpers.py
@@ -73,3 +73,23 @@ def unicodifier(obj):
     elif isinstance(obj, dict):
         return dict((key, unicodifier(value)) for key, value in obj.iteritems())
     return obj
+
+
+def utf8ifier(obj):
+    """
+    Tries to (recursively) convert the given object into utf8.
+
+    :param obj: the object to convert
+        (can be e.g. unicode, str, list, tuple, dict)
+    """
+    if isinstance(obj, str):
+        return obj
+    elif isinstance(obj, unicode):
+        return obj.encode('utf8')
+    elif isinstance(obj, list):
+        return [utf8ifier(elem) for elem in obj]
+    elif isinstance(obj, tuple):
+        return tuple(utf8ifier(elem) for elem in obj)
+    elif isinstance(obj, dict):
+        return dict((key, utf8ifier(value)) for key, value in obj.iteritems())
+    return obj

--- a/invenio/base/i18n.py
+++ b/invenio/base/i18n.py
@@ -53,8 +53,11 @@ def gettext_set_language(ln, use_unicode=False):
     from invenio.ext.babel import set_locale
     with set_locale(ln):
         if not use_unicode:
-            def unicode_gettext_wrapper(*args, **kwargs):
-                return gettext(*args, **kwargs).encode('utf-8')
+            def unicode_gettext_wrapper(text, **kwargs):
+                from invenio.base.helpers import unicodifier
+                from invenio.utils.text import wash_for_utf8
+                return wash_for_utf8(gettext(unicodifier(text),
+                                             **unicodifier(kwargs)))
             return unicode_gettext_wrapper
         return gettext
 

--- a/invenio/ext/confighacks.py
+++ b/invenio/ext/confighacks.py
@@ -43,7 +43,8 @@ def setup_app(app):
             elif name == '__path__':
                 return os.path.dirname(__file__)
             try:
-                return self.wrapped[name]
+                from invenio.base.helpers import utf8ifier
+                return utf8ifier(self.wrapped[name])
             except:
                 pass
                 #import traceback


### PR DESCRIPTION
- Encodes legacy `invenio.config` to utf8 and fixes handling of
  translatable utf8 strings.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
Co-authored-by: Adrian-Tudor Panescu adrian.tudor.panescu@cern.ch
