### PR TITLE
workflows: move persistent_ids to extra_data

### DIFF
--- a/invenio/modules/workflows/models.py
+++ b/invenio/modules/workflows/models.py
@@ -233,7 +233,6 @@ class BibWorkflowObject(db.Model):
     modified = db.Column(db.DateTime, default=datetime.now,
                          onupdate=datetime.now, nullable=False)
     status = db.Column(db.String(255), default="", nullable=False)
-    persistent_ids = db.Column(db.JSON, default={}, nullable=True)
     data_type = db.Column(db.String(150), default="",
                           nullable=True)
     uri = db.Column(db.String(500), default="")

--- a/invenio/modules/workflows/tasks/marcxml_tasks.py
+++ b/invenio/modules/workflows/tasks/marcxml_tasks.py
@@ -604,7 +604,7 @@ def quick_match_record(obj, eng):
         if not identifiers:
             return False
         else:
-            obj.persistent_ids = identifiers
+            obj.extra_data["persistent_ids"] = identifiers
     except KeyError:
         identifiers = {}
 
@@ -613,7 +613,7 @@ def quick_match_record(obj, eng):
             recid = function_dictionnary[identifier](identifiers[identifier]["value"])
             if recid:
                 obj.data['recid']['value'] = recid
-                obj.persistent_ids["recid"] = recid
+                obj.extra_data["persistent_ids"]["recid"] = recid
                 return True
         return False
     else:


### PR DESCRIPTION
- Moves the persistent_ids column into an extra_data field.
- Changes tasks appropriately.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
