### PR TITLE
workflows: change default XSLT

### DIFF
--- a/invenio/modules/workflows/workflows/full_doc_process.py
+++ b/invenio/modules/workflows/workflows/full_doc_process.py
@@ -38,7 +38,7 @@ from invenio.config import CFG_PREFIX
 
 class full_doc_process(object):
     object_type = "record"
-    workflow = [convert_record_with_repository("oaiarXiv2inspire_nofilter.xsl"), convert_record_to_bibfield,
+    workflow = [convert_record_with_repository("oaiarxiv2marcxml.xsl"), convert_record_to_bibfield,
                 workflow_if(quick_match_record, True),
                 [
                     plot_extract(["latex"]),


### PR DESCRIPTION
- Changes the XSLT parameter in the example workflow
  "full_doc_process".

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
