### PR TITLE
jsonalchemy: StorageEngine metaclass addition

### DIFF
--- a/invenio/modules/annotations/api.py
+++ b/invenio/modules/annotations/api.py
@@ -17,24 +17,9 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from flask import g
-from werkzeug.local import LocalProxy
-
 from invenio.base.globals import cfg
-from invenio.modules.jsonalchemy.jsonext.engines.mongodb_pymongo import \
-    MongoDBStorage
 from invenio.modules.jsonalchemy.reader import Reader
 from invenio.modules.jsonalchemy.wrappers import SmartJsonLD
-
-
-def get_storage_engine():
-    if not hasattr(g, "annotations_storage_engine"):
-        g.annotations_storage_engine = \
-            MongoDBStorage("Annotation",
-                           host=cfg["ANNOTATIONS_MONGODB_HOST"],
-                           port=cfg["ANNOTATIONS_MONGODB_PORT"],
-                           database=cfg["CFG_DATABASE_NAME"])
-    return g.annotations_storage_engine
 
 
 class QueryIterator():
@@ -62,7 +47,8 @@ class QueryIterator():
 
 
 class Annotation(SmartJsonLD):
-    storage_engine = LocalProxy(get_storage_engine)
+
+    __storagename__ = 'annotations'
 
     @classmethod
     def create(cls, data, model='annotation', store=True):

--- a/invenio/modules/annotations/config.py
+++ b/invenio/modules/annotations/config.py
@@ -17,8 +17,17 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-ANNOTATIONS_MONGODB_HOST = "localhost"
-ANNOTATIONS_MONGODB_PORT = 27017
+from invenio.base import config
+
+ANNOTATIONS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.'
+                      'mongodb_pymongo:MongoDBStorage')
+
+
+ANNOTATIONS_MONGODBSTORAGE = {
+    'host': "localhost",
+    'port': 27017,
+    'database': config.CFG_DATABASE_NAME,
+}
 
 ANNOTATIONS_ATTACHMENTS = False
 

--- a/invenio/modules/documents/api.py
+++ b/invenio/modules/documents/api.py
@@ -50,33 +50,18 @@ import fs
 import six
 
 from datetime import datetime
-from flask import g
 from fs.opener import opener
-from werkzeug.utils import import_string
-from werkzeug.local import LocalProxy
 
-from invenio.base.globals import cfg
 from invenio.modules.jsonalchemy.wrappers import SmartJson
 from invenio.modules.jsonalchemy.reader import Reader
 
 from . import signals, errors
 
 
-def get_storage_engine():
-    if not hasattr(g, "documents_storage_engine"):
-        engine = cfg['DOCUMENTS_ENGINE']
-        if isinstance(engine, six.string_types):
-            engine = import_string(engine)
-
-        key = engine.__name__.upper()
-        kwargs = cfg.get('DOCUMENTS_{0}'.format(key), {})
-        g.documents_storage_engine = engine(**kwargs)
-    return g.documents_storage_engine
-
-
 class Document(SmartJson):
     """Document"""
-    storage_engine = LocalProxy(get_storage_engine)
+
+    __storagename__ = 'documents'
 
     @classmethod
     def create(cls, data, model='document_base', master_format='json',

--- a/invenio/modules/jsonalchemy/jsonext/engines/memory.py
+++ b/invenio/modules/jsonalchemy/jsonext/engines/memory.py
@@ -37,7 +37,7 @@ class MemoryStorage(Storage):
         """
         See also :meth:`~invenio.modules.jsonalchemy.storage:Storage.__init__`
         """
-        self._database = kwargs.get('database', {})
+        self._database = kwargs.get('database', dict())
 
     def save_one(self, data, id=None):
         """See :meth:`~invenio.modules.jsonalchemy.storage:Storage.save_one`"""

--- a/invenio/modules/jsonalchemy/testsuite/test_storage_engine.py
+++ b/invenio/modules/jsonalchemy/testsuite/test_storage_engine.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Unit tests for the storage engine."""
+
+from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+
+
+def class_factory(name):
+    from invenio.modules.jsonalchemy.wrappers import SmartJson
+
+    class DummyJson(SmartJson):
+        __storagename__ = name
+    return DummyJson
+
+
+class TestStorageEngineConfig(InvenioTestCase):
+    """Test for configuration of storage engine."""
+
+    def test_string_config(self):
+        self.app.config['DUMMY_ENGINE'] = ('invenio.modules.jsonalchemy.'
+                                           'jsonext.engines.memory:'
+                                           'MemoryStorage')
+        DummyJson = class_factory('dummy')
+        database = {1: DummyJson({'_id': 1}, master_format='json',
+                                 namespace='json')}
+        self.app.config['DUMMY_MEMORYSTORAGE'] = {
+            'database': database
+        }
+
+        self.assertEqual(DummyJson.storage_engine.get_one(1)['_id'],
+                         database[1]['_id'])
+
+    def test_instance_config(self):
+        from invenio.modules.jsonalchemy.jsonext.engines import memory
+        self.app.config['DUMMY_ENGINE'] = memory.MemoryStorage
+        DummyJson = class_factory('dummy')
+        database = {1: DummyJson({'_id': 1}, master_format='json',
+                                 namespace='json')}
+        self.app.config['DUMMY_MEMORYSTORAGE'] = {
+            'database': database
+        }
+
+        self.assertEqual(DummyJson.storage_engine.get_one(1)['_id'],
+                         database[1]['_id'])
+
+TEST_SUITE = make_test_suite(TestStorageEngineConfig)
+
+if __name__ == '__main__':
+    run_test_suite(TEST_SUITE)

--- a/invenio/modules/records/api.py
+++ b/invenio/modules/records/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -25,11 +25,9 @@
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.utils import cached_property
 
-from invenio.modules.jsonalchemy.jsonext.engines.sqlalchemy import SQLAlchemyStorage
 from invenio.modules.jsonalchemy.reader import Reader
 from invenio.modules.jsonalchemy.wrappers import SmartJson
 
-from .models import RecordMetadata as RecordMetadataModel
 from .models import Record as RecordModel
 
 
@@ -37,8 +35,6 @@ class Record(SmartJson):
     """
     Default/Base record class
     """
-
-    storage_engine = SQLAlchemyStorage(RecordMetadataModel)
 
     def __init__(self, json=None, **kwargs):
         if not json or '__meta_metadata__' not in json:
@@ -71,7 +67,8 @@ class Record(SmartJson):
         if record_sql_model is None or blob is None:
             return None
         additional_info = record_sql_model.additional_info \
-                if record_sql_model.additional_info else {'master_format': 'marc'}
+            if record_sql_model.additional_info \
+            else {'master_format': 'marc'}
         record = cls.create(blob, **additional_info)
         record._save()
         record_sql_model.additional_info = record.additional_info

--- a/invenio/modules/records/config.py
+++ b/invenio/modules/records/config.py
@@ -17,6 +17,15 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+from .models import RecordMetadata as RecordMetadataModel
+
 
 RECORDS_BREADCRUMB_TITLE_KEY = 'title.title'
 """ Key used to extract the breadcrumb title from the record """
+
+RECORDS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.sqlalchemy'
+                  ':SQLAlchemyStorage')
+
+RECORDS_SQLALCHEMYSTORAGE = {
+    'model': RecordMetadataModel,
+}


### PR DESCRIPTION
- Adds metaclass that reads `__storagename__` class attribute used as
  prefix for reading the configuration.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
