### PR TITLE
docs: how to develop modules

### DIFF
--- a/docs/developers/extensions.rst
+++ b/docs/developers/extensions.rst
@@ -14,7 +14,7 @@ extension running.
 .. _Flask Extension Registry: http://flask.pocoo.org/extensions/
 .. _Flask Extension Development: http://flask.pocoo.org/docs/extensiondev/
 
-Pluging an Existing Extension
+Plugging an Existing Extension
 -----------------------------
 
 Extensions are all located in a package called ``flask_something``

--- a/docs/developers/howtomodule.rst
+++ b/docs/developers/howtomodule.rst
@@ -1,0 +1,70 @@
+.. _developers-howtomodule:
+
+How to develop a module: Part 1
+===============================
+
+This page summarizes the standard structure and naming conventions of a
+module in Invenio v2.0.0. It serves as a reference point when developing
+a new module, enhancing an existing one or porting a module from
+older versions of Invenio.
+
+The previous pages explained briefly what a module usually consists of, here
+we will go deeper into what goes where inside the module.
+
+Overview
+--------
+
+A simple module may have the following folder structure::
+
+    invenio/modules/
+        mymodule/
+            __init__.py
+            api.py
+            models.py
+            config.py
+            views.py
+
+These files are:
+
+``___init__.py``
+    (usually) an empty file that tells Python that this directory should be considered a Python package.
+    Sometimes module level documentation are put here.
+
+``models.py``
+    contains the data model for the modules (written as SQLAlchemy models). See how (link here)
+
+``config.py``
+    contains module-wide configuration with prefix ``MYMODULE_*``. See how to import (link here)
+
+``views.py``
+    contains Flask blueprints if the module requires a web-interface. Multiple views? (link here)
+
+``api.py``
+    contains the API for other modules to access features of this module.
+
+
+Additional files:
+
+``signals.py``
+    define custom signals here. See signals module.
+
+``receivers.py``
+    define your custom signal receivers here. See signals module.
+
+``errors.py``
+    contains any custom module-specific exceptions. For example::
+
+        class MyException(Exception): pass
+
+``user_settings.py``
+    TODO
+
+``forms.py``
+    TODO
+
+``tasks.py``
+    TODO
+
+``restful.py``
+    TODO
+

--- a/docs/developers/howtomodulepart2.rst
+++ b/docs/developers/howtomodulepart2.rst
@@ -1,0 +1,34 @@
+.. _developers-howtomodulepart2:
+
+How to develop a module: Part 2
+===============================
+
+In part 2 of this guide, we will go into some more advance module structures
+and usage.
+
+
+Multiple views
+--------------
+
+If your module have several web interface entry points, such as an admin area and a user area.
+``views`` are defined inside it's own folder::
+
+    invenio/modules/
+        mymodule/
+            views/
+                __init__.py
+                admin.py
+                user.py
+
+The ``__init__.py`` file then contains special code to include the views::
+
+    from .user import blueprint as user_blueprint
+    from .admin import blueprint as admin_blueprint
+
+    blueprints = [user_blueprint, admin_blueprint]
+
+
+Module-wide configuration
+-------------------------
+
+TODO.

--- a/docs/developers/howtomodulepart3.rst
+++ b/docs/developers/howtomodulepart3.rst
@@ -1,0 +1,15 @@
+.. _developers-howtomodulepart3:
+
+How to develop a module: Part 3
+===============================
+
+
+Tests
+-----
+
+TODO
+
+Documentation
+-------------
+
+TODO

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -11,6 +11,9 @@ Developer's Guide
    extensions
    registries
    modules
+   howtomodule
+   howtomodulepart2
+   howtomodulepart3
    templates
    git-workflow
    kwalitee

--- a/docs/developers/introduction.rst
+++ b/docs/developers/introduction.rst
@@ -22,7 +22,7 @@ Before you start reading please
 - *Agile Development* where each iteration should lead to working code
   in relatively short time while incremental step are small and easy to
   understand by other developers. When you start with development take
-  advantage of built-in tools provided by Python and undelying libraries::
+  advantage of built-in tools provided by Python and underlying libraries::
 
     # Install package in editable mode
     $ pip install -e git+http://invenio-software.org/repo/invenio.git
@@ -57,7 +57,7 @@ Modules
 -------
 
 Modules are application components that can be use within an application
-or across aplications.  They can contains `SQLAlchemy`_ models, `Flask`_
+or across applications.  They can contains `SQLAlchemy`_ models, `Flask`_
 views, `Jinja2`_ templates and other ref:`pluggable-objects`.
 
 Discovery of modules is done based on configuration parameter called


### PR DESCRIPTION
- Adds documentation for how to develop modules in Invenio
  v2.0.0. Still work in progress.
- Fixes typo in extensions.rst and introduction.rst.

In reference to #161. What do you guys think about this setup? Before I go further..
