### PR TITLE
search: fix initial request missing stylsheets.

### DIFF
--- a/invenio/modules/search/templates/search/searchbar_frame.html
+++ b/invenio/modules/search/templates/search/searchbar_frame.html
@@ -32,9 +32,7 @@
   {% js url_for('static', filename='js/bootstrap-select.js') %}
 {#  {% js "js/jquery.hotkeys.js" %}#}
 {#  {% js url_for('search.static', filename='js/search/hotkeys.js') %}#}
-{% endblock %}
 
-{% block css %}
   {%- css url_for('static', filename='css/typeahead.js-bootstrap.css'), '50-search' -%}
   {%- css url_for('static', filename='css/search/searchbar.css'), '50-search' -%}
 {% endblock %}


### PR DESCRIPTION
Putting the stylesheets into the `header` block fixes it.
The `css` block occurs after `css_bundle()` so they don't make it the first time. As everything goes through _Flask Assets_, using the `header` block for JS and CSS seems the way to go.

See #186, ping @lnielsen-cern
