### PR TITLE
search: fix decoding Unicode is not supported.

### DIFF
--- a/invenio/modules/search/admin_forms.py
+++ b/invenio/modules/search/admin_forms.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Invenio.
-## Copyright (C) 2011 CERN.
+## Copyright (C) 2011, 2014 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -19,23 +19,17 @@
 
 """WebMessage Forms"""
 
-from string import strip
-from datetime import datetime
-from invenio.ext.sqlalchemy import db
 from invenio.base.i18n import _
 from invenio.modules.search.models import get_pbx_pos
-from flask.ext.wtf import Form
-from invenio.utils.forms import InvenioBaseForm, FilterForm, DateTimePickerWidget, FilterTextField
-from wtforms import DateTimeField, BooleanField, TextField, TextAreaField, \
-                    PasswordField, validators, HiddenField, FieldList, SelectField
+from invenio.utils.forms import InvenioBaseForm
+from wtforms import TextField, HiddenField, SelectField
 
-
-# from invenio.base.i18n import language_list_long
 
 class CollectionForm(InvenioBaseForm):
     id = HiddenField()
     name = TextField(_('Name'))
     dbquery = TextField(_('Query'))
+
 
 def TranslationsForm(language_list_long, values):
 
@@ -43,12 +37,13 @@ def TranslationsForm(language_list_long, values):
         collection_id = HiddenField()
 
     for (lang, lang_long) in language_list_long:
-        setattr( _TranslationsForm, lang,  TextField(_(unicode(lang_long,"utf-8")), default = \
-            values.get(lang, '')))
+        setattr(_TranslationsForm, lang,
+                TextField(_(lang_long),
+                          default=values.get(lang, '')))
 
-    return  _TranslationsForm
+    return _TranslationsForm
 
 
 class PortalBoxForm(InvenioBaseForm):
     id = HiddenField()
-    postion = SelectField(u'Select Position', get_pbx_pos() )
+    postion = SelectField(u'Select Position', get_pbx_pos())


### PR DESCRIPTION
**Problem**

Visit `/admin/websearch/collection/view/Articles%20%26%20Preprints`

```
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/vagrant/invenio/invenio/ext/legacy/__init__.py", line 61, in __call__
    response = self.app.handle_exception(e)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask_restful/__init__.py", line 258, in error_router
    return original_handler(e)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/vagrant/invenio/invenio/ext/legacy/__init__.py", line 57, in __call__
    response = self.app.full_dispatch_request()
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask_restful/__init__.py", line 258, in error_router
    return original_handler(e)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask_login.py", line 658, in decorated_view
    return func(*args, **kwargs)
  File "/home/vagrant/.virtualenvs/pu/lib/python2.7/site-packages/flask_principal.py", line 199, in _decorated
    rv = f(*args, **kw)
  File "/home/vagrant/invenio/invenio/modules/search/views/admin.py", line 159, in manage_collection
    TranslationsFormFilled = TranslationsForm(language_list_long(), translations)
  File "/home/vagrant/invenio/invenio/modules/search/admin_forms.py", line 46, in TranslationsForm
    setattr( _TranslationsForm, lang,  TextField(_(unicode(lang_long,"utf-8")), default = \
TypeError: decoding Unicode is not supported
```

**Solution**

the input string is already a `unicode` object, so there is no need to decode it.

``` diff
- unicode(lang_long,"utf-8")
+ lang_long
```
