### PR TITLE
installation: virtualenv based path for static

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,10 +21,11 @@
 
 
 module.exports = function (grunt) {
-    var globalConfig = {
-        bower_path: 'bower_components',
-        installation_path: '../../var/invenio.base-instance/static' // default path
-    };
+    var prefix = process.env.VIRTUAL_ENV || '../..'
+      , globalConfig = {
+            bower_path: 'bower_components',
+            installation_path: prefix + '/var/invenio.base-instance/static'
+        };
 
     // target for custom path
     if (grunt.option('path')) {


### PR DESCRIPTION
Relative path fails if you're using symlinks for `src/invenio` or want to use a different directory layout.

It also kind of matches the way the static path is built: https://github.com/jirikuncar/invenio/blob/d9fcead025afa7653cfabaedea563a4b24a6c1c8/invenio/base/factory.py#L108-L111
