### PR TITLE
docs: INSTALL guide update

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -138,7 +138,6 @@ for quick start.
     (invenio)$ git-new-workdir ~/src/invenio-demosite/ invenio-demosite $BRANCH
     (invenio)$ cd invenio-demosite
     (invenio)$ pip install -e .
-    (invenio)$ inveniomanage config set PACKAGES "['invenio_demosite', 'invenio.modules.*']"
 
 
 c. Development


### PR DESCRIPTION
- Updates the INSTALL guide to remove suggested command to set
  PACKAGES config manually. This is now managed at the level of
  the demosite sources via setup.py entry_points.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
