### PR TITLE
workflows: load Celery worker tasks

### DIFF
--- a/invenio/modules/workflows/tasks/__init__.py
+++ b/invenio/modules/workflows/tasks/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import absolute_import
+
+from ..workers.worker_celery import (celery_continue,
+                                     celery_run,
+                                     celery_restart)
+
+__all__ = ['celery_continue', 'celery_run', 'celery_restart']


### PR DESCRIPTION
- Loads the Celery worker tasks so that Invenio Celery wrapper
  can discover the tasks.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
