### PR TITLE
assets: "less" flavor of bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ install:
   - "sudo add-apt-repository -y ppa:chris-lea/node.js"
   - "sudo apt-get update"
   - "sudo apt-get install apache2 libapache2-mod-wsgi ssl-cert poppler-utils git subversion nodejs --fix-missing"
-  - "sudo su -c \"npm install -g bower grunt-cli\""
-  - "npm install"
-  - "bower install"
   - "sudo a2enmod actions"
   - "sudo a2enmod version"
   - "sudo a2enmod rewrite"
@@ -54,6 +51,11 @@ install:
   - "inveniomanage config set CFG_BIBSCHED_PROCESS_USER `whoami`"
   - "inveniomanage config set PACKAGES_EXCLUDE []"  # test all packages
   - "inveniomanage config set CFG_TMPDIR /tmp"  # test all packages
+  - "sudo su -c \"npm install -g bower grunt-cli\""
+  - "npm install"
+  - "inveniomanage config set CLEANCSS_BIN `find $PWD/node_modules -iname \"cleancss\" | grep \"\\.bin\" | head -1`"
+  - "inveniomanage config set LESS_BIN `find $PWD/node_modules -iname \"lessc\" | grep \"\\.bin\" | head -1`"
+  - "bower install"
   - "travis_retry grunt"
   - "inveniomanage collect"
 

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "bootstrap": "3.1.1",
+    "less": "1.7.0",
     "jquery": "2.1.0",
     "font-awesome": "~4.0.3",
     "ckeditor": "latest"

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -27,9 +27,7 @@ module.exports = {
         expand: true,
         flatten: true,
         cwd: '<%= globalConfig.bower_path %>',
-        src: ['bootstrap/dist/css/bootstrap*'
-               ,'font-awesome/css/font-awesome.*'
-               ,'jquery-tokeninput/styles/token-input-facebook.css'
+        src: ['jquery-tokeninput/styles/token-input-facebook.css'
                ,'jquery-tokeninput/styles/token-input.css'
                ,'jquery.bookmark/jquery.bookmark.css'
                ,'datatables-colvis/css/dataTables.colVis.css'
@@ -37,6 +35,20 @@ module.exports = {
                ,'prism/prism.css'
                ,'bootstrap-tagsinput/dist/bootstrap-tagsinput.css'],
         dest: '<%= globalConfig.installation_path %>/css/'
+    },
+    less_bootstrap: {
+        expand: true,
+        flatten: true,
+        cwd: '<%= globalConfig.bower_path %>',
+        src: ['bootstrap/less/*.less'],
+        dest: '<%= globalConfig.installation_path %>/less/bootstrap'
+    },
+    less_fontawesome: {
+        expand: true,
+        flatten: true,
+        cwd: '<%= globalConfig.bower_path %>',
+        src: ['font-awesome/less/*.less'],
+        dest: '<%= globalConfig.installation_path %>/less/font-awesome'
     },
     jquery_css: {
         expand: true,
@@ -279,6 +291,15 @@ module.exports = {
                 src = 'jquery-migrate.js'
             }
             return dest + src;
+        }
+    },
+    lesscss: {
+        expand: true,
+        cwd: '<%= globalConfig.bower_path %>/less/dist',
+        src: ['less-1.7.0.*'],
+        dest: '<%= globalConfig.installation_path %>/js/',
+        rename: function(dest, src) {
+            return dest + src.replace(/-\d\.\d\.\d/, '');
         }
     }
 };

--- a/invenio/base/static/less/base.less
+++ b/invenio/base/static/less/base.less
@@ -1,3 +1,6 @@
+@import "bootstrap/bootstrap.less";
+@import "font-awesome/font-awesome.less";
+
 body {
 	padding-top: 70px;
 }

--- a/invenio/base/templates/_macros.html
+++ b/invenio/base/templates/_macros.html
@@ -40,7 +40,7 @@
 {%- macro css_bundle() -%}
   {%- for bundle in get_css_bundle(iterate=True) -%}
     {%- assets bundle -%}
-      <link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}"/>
+    <link rel="{{ EXTRA.rel }}" type="text/css" href="{{ ASSET_URL }}"/>
     {% endassets -%}
   {%- endfor -%}
 {%- endmacro -%}

--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -21,11 +21,9 @@
 
 {# Global CSS #}
 {%- block global_css %}
-  {%- css url_for('static', filename='css/bootstrap.css'), '00-invenio' -%}
-  {%- css url_for('static', filename='css/font-awesome.min.css'), '00-invenio' -%}
-  {%- css url_for('static', filename='css/token-input.css'), '00-invenio' -%}
-  {%- css url_for('static', filename='css/token-input-facebook.css'), '00-invenio' -%}
-  {%- css url_for('base.static', filename='css/base.css'), '00-invenio' -%}
+  {%- css url_for('static', filename="css/token-input.css"), '00-invenio' -%}
+  {%- css url_for('static', filename="css/token-input-facebook.css"), '00-invenio' -%}
+  {%- css url_for('base.static', filename='less/base.less'), '00-invenio', 'less,cleancss' -%}
   {%- css url_for('webtag.static', filename='css/tags/popover.css'), '00-invenio' -%}
   {%- if config.CFG_WEBSTYLE_TEMPLATE_SKIN != 'default' %}
     {%- css url_for('static', filename='css/'+config.CFG_WEBSTYLE_TEMPLATE_SKIN+'.css'), '00-invenio' -%}
@@ -40,6 +38,9 @@
   {%- js url_for('static', filename='js/hogan.js'), '10-invenio' -%}
   {%- js url_for('base.static', filename='js/translate.js'), '10-invenio' -%}
   {%- js url_for('base.static', filename='js/invenio.js'), '90-invenio' -%}
+  {%- if config.get('ASSETS_DEBUG') and not config.get("LESS_RUN_IN_DEBUG", True) -%}
+    {%- js url_for('static', filename='js/less.js'), '99-less' -%}
+  {%- endif -%}
 {%- endblock global_javascript %}
 {%- block page -%}
 {%- if not no_pageheader -%}

--- a/invenio/ext/legacy/__init__.py
+++ b/invenio/ext/legacy/__init__.py
@@ -79,8 +79,9 @@ def setup_app(app):
             if not isinstance(response, BaseResponse):
                 response = current_app.make_response(str(response))
             return response
-        except HTTPException:
-            pass
+        except HTTPException as e:
+            current_app.logger.exception(request.path)
+            error = e
         if error.code == 404:
             return render_template('404.html'), 404
         return str(error), error.code

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "grunt-contrib-cssmin": "*",
     "grunt-contrib-clean": "*",
     "grunt-contrib-uglify": "*",
+    "grunt-contrib-less": "*",
     "load-grunt-config": "*",
     "grunt-newer": "*",
     "grunt-concurrent": "*"


### PR DESCRIPTION
- Installing less.
- Enabling filters on the assets `{% css "foo.css", "00-bundle", "less" %}`
- Adding one extra configuration key: `LESS_BIN` which must be pointed to lessc: e.g., `node_modules/grunt-contrib-less/node_modules/.bin/lessc`

Inspire are already using less but have to compile it everytime, this would make it all dynamic: https://github.com/inspirehep/inspire-next/tree/new-templates
