### PR TITLE
jsonalchemy: default values for subfields

### DIFF
--- a/invenio/modules/jsonalchemy/testsuite/fields/fields.cfg
+++ b/invenio/modules/jsonalchemy/testsuite/fields/fields.cfg
@@ -261,6 +261,21 @@ dummy:
     producer:
         json_for_dummy(), {'foo': ''}
 
+default_values_test:
+    """Test field for default value, including subfields"""
+    schema:
+        {'default_values_test': {
+            'type': 'dict',
+            'required': True,
+            'schema': {
+                'field1': {'type': 'boolean', 'required': True, 'default': lambda: True},
+                'field2': {'default': lambda:False}
+                }
+            }
+        }
+    derived:
+        {'field1': False, 'field3': False}
+
 @extend
 dummy:
     derived:

--- a/invenio/modules/jsonalchemy/testsuite/test_readers.py
+++ b/invenio/modules/jsonalchemy/testsuite/test_readers.py
@@ -128,6 +128,8 @@ class TestJSONReader(InvenioTestCase):
         self.assertTrue(all([key in json for key in blob.keys()]))
         self.assertTrue('__meta_metadata__' in json)
         self.assertTrue('modification_date' in json)
+        self.assertEquals(json['default_values_test'],
+                          {'field2': False, 'field3': False, 'field1': False})
 
     def test_json_reader_add_and_set_fields(self):
         """JSONAlchemy - add and set fields"""


### PR DESCRIPTION
- Fixes jsonalchemy ignoring default values when the main field is
  present but not one of the subfields. (closes #34)

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
