### PR TITLE
connector: InvenioConnector URL validation

### DIFF
--- a/invenio/testsuite/test_utils_connector.py
+++ b/invenio/testsuite/test_utils_connector.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Invenio.
+## Copyright (C) 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+
+"""
+Test unit for the utils/connector
+"""
+
+from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+from invenio.base.wrappers import lazy_import
+
+
+InvenioConnector = lazy_import('invenio.utils.connector:InvenioConnector')
+
+
+class ConnectorTest(InvenioTestCase):
+    """Test function to get default values."""
+
+    def test_url_errors(self):
+        """InvenioConnector - URL errors"""
+        from invenio.utils.connector import InvenioConnectorServerError
+        InvenioConnector('http://cds.cern.ch')
+        invalid_urls = [
+            'htp://cds.cern.ch',
+            'cds.cern.ch',
+            'http://thecerndocumentserver.cern.ch',
+            'invalidurl',
+            'http://mgfldgmdflgmdfklgmklmkdflg.com'
+        ]
+        for url in invalid_urls:
+            self.assertRaises(InvenioConnectorServerError,
+                              InvenioConnector, url)
+
+
+TEST_SUITE = make_test_suite(ConnectorTest, )
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- InvenioConnector will now throw an InvenioConnectorServerError
  exception is the given URL is invalid.

Signed-off-by: Graham R. Armstrong graham.richard.armstrong@cern.ch
