### PR TITLE
collect: bugfix to not symlink yourself done right

### DIFF
--- a/invenio/ext/collect/__init__.py
+++ b/invenio/ext/collect/__init__.py
@@ -27,6 +27,11 @@ collect = Collect()
 def setup_app(app):
     """Set the application up with the corresct static root."""
     app.config['COLLECT_STATIC_ROOT'] = app.static_folder
-    # unsetting the static_folder so it's not picked up by collect.
-    app.static_folder = None
     collect.init_app(app)
+
+    # unsetting the static_folder so it's not picked up by collect.
+    class FakeApp(object):
+        has_static_folder = False
+        static_folder = None
+
+    collect.app = FakeApp()


### PR DESCRIPTION
Using a FakeApp to not interfer with the real app. The previous fix (#244) was unsetting the `static_folder` globally.

**label:** hack
