### PR TITLE
base: wsgi middlewares reorganization

### DIFF
--- a/invenio/base/templates/invenio-apache-vhost.tpl
+++ b/invenio/base/templates/invenio-apache-vhost.tpl
@@ -90,13 +90,17 @@ WSGIPythonHome {{pythonhome}}
         AliasMatch /sitemap-(.*) {{ config.CFG_WEBDIR }}/sitemap-$1
     {%- endblock aliases -%}
     {%- block wsgi %}
-        WSGIScriptAlias /wsgi {{ config.CFG_WSGIDIR }}/invenio.wsgi
+        # Name of the WSGI entry point.
+        # Change it at the *three* locations if you have to.
+        {%- set script_alias = "/wsgi" %}
+        SetEnv WSGI_SCRIPT_ALIAS {{ script_alias }}
+        WSGIScriptAlias {{ script_alias }} {{ config.CFG_WSGIDIR }}/invenio.wsgi
         WSGIPassAuthorization On
 
         RewriteEngine on
         RewriteCond {{ config.COLLECT_STATIC_ROOT }}%{REQUEST_FILENAME} !-f
         RewriteCond {{ config.COLLECT_STATIC_ROOT }}%{REQUEST_FILENAME} !-d
-        RewriteRule ^(.*)$ /wsgi$1 [PT,L]
+        RewriteRule ^(.*)$ {{ script_alias }}$1 [PT,L]
     {% endblock wsgi -%}
     {%- block xsendfile_directive %}
         {{ '#' if not config.CFG_BIBDOCFILE_USE_XSENDFILE }}XSendFile On

--- a/invenio/invenio.wsgi
+++ b/invenio/invenio.wsgi
@@ -16,14 +16,14 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-mod_wsgi Invenio application loader.
-"""
+"""mod_wsgi Invenio application loader."""
+
+import sys
+from invenio.base.factory import create_wsgi_app
 
 ## You can't write to stdout in mod_wsgi, but some of our
 ## dependecies do this! (e.g. 4Suite)
-import sys
 sys.stdout = sys.stderr
 
-from invenio.base.factory import create_wsgi_app
+
 application = create_wsgi_app()


### PR DESCRIPTION
**Problems**
I'm serving invenio using uWSGI:

``` console
$ uwsgi --master --processes 4 --die-on-term --http 0.0.0.0:4000 --wsgi-file invenio/invenio.wsgi
AttributeError: 'DebuggedApplication' object has no attribute 'wsgi_app'
...
assert self.script_name == environ['SCRIPT_NAME']
AssertionError
```

**Changes**
- Fixing DebbugedApplication middleware usage. ([_why uWSGI requires it_](http://stackoverflow.com/a/17839750))
- Using an Apache environment variable (`WSGI_SCRIPT_ALIAS`) to detect when to apply the `WSGIScriptAliasFix`.
- **NOTE** <span style="color:#f00">regenerate your apache configuration</span>.

**Notes**
- `%{ENV:WSGI_SCRIPT_ALIAS}` doesn't work(?)
- the Apache environment can only be accessed at `__call__` time.

Related to: #254
