### PR TITLE
search: collection template loading

### DIFF
--- a/invenio/modules/search/views/search.py
+++ b/invenio/modules/search/views/search.py
@@ -171,7 +171,8 @@ def collection(name):
             easy_search_form=EasySearchForm(csrf_enabled=False),
             breadcrumbs=current_breadcrumbs + collection.breadcrumbs(ln=g.ln)[1:])
 
-    return render_template(['search/collection_{0}.html'.format(slugify(name,
+    return render_template(['search/collection_{0}.html'.format(collection.id),
+                            'search/collection_{0}.html'.format(slugify(name,
                                                                         '_')),
                             'search/collection.html'],
                            collection=collection)


### PR DESCRIPTION
- Supports collection specific templates by id `collection_{id}.html` with
  fallback to the `collection_{name}.html` and `collection.html`.

Signed-off-by: Charalampos Tzovanakis drjova@cern.ch
