### PR TITLE
base: footer modularity improvement

### DIFF
--- a/invenio/base/static/css/base.css
+++ b/invenio/base/static/css/base.css
@@ -2,12 +2,16 @@ body {
 	padding-top: 70px;
 }
 
-footer a, footer a:hover {
+#footer a, #footer a:hover {
   color: #666;
 }
-footer, footer p {
+#footer, #footer p {
   font-size: 11px;
   color: #333;
+}
+
+#footer .langs {
+  text-align: right;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
@@ -16,7 +20,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 
 /* Lastly, apply responsive CSS fixes as necessary */
 @media (max-width: 767px) {
-  footer {
+  #footer {
     margin-left: -20px;
     margin-right: -20px;
     padding-left: 20px;
@@ -103,5 +107,4 @@ body {
 /* Set the fixed height of the footer here */
 #footer {
   height: 150px;
-  background-color: #f5f5f5;
 }

--- a/invenio/base/templates/footer_base.html
+++ b/invenio/base/templates/footer_base.html
@@ -24,30 +24,49 @@
 ## {% include 'footer.html' %}
 #}
 
+{%- block footer -%}
 <div class="container">
   <hr/>
   <div class="row">
-  <div class="col-md-6">
-  {{ config["CFG_SITE_NAME_INTL"][g.ln] }} &nbsp;::&nbsp;<a class="footer" href="{{ url_for('') }}">{{ _("Search") }}</a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('webdeposit.index') }}">{{ _("Deposit") }}</a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('webaccount.index') }}">{{ _("Personalize") }}</a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('help') }}">{{ _("Help") }}</a>
-  <br />
-  {{ _("Powered by") }} <a class="footer" href="http://invenio-software.org/">Invenio</a> v{{ config.CFG_VERSION }}
-  <br />
-  {{ _("Maintained by") }} <a class="footer" href="mailto:{{ config.CFG_SITE_SUPPORT_EMAIL }}">{{ config.CFG_SITE_SUPPORT_EMAIL }}</a>
-  <br />
-  {% if lastupdated %}
+    <div class="col-md-6">
+{%- block footer_credits %}
+      {{ config["CFG_SITE_NAME_INTL"][g.ln] }}
+      &nbsp;::&nbsp;<a class="footer" href="{{ url_for('search.index') }}">
+        {{- _("Search") -}}
+      </a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('webdeposit.index') }}">
+        {{- _("Deposit") -}}
+      </a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('webaccount.index') }}">
+        {{- _("Personalize") -}}
+      </a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('help') }}">
+        {{- _("Help") -}}
+      </a><br/>
+      {{ _("Powered by") }} <a class="footer" href="http://invenio-software.org/">Invenio</a>
+      v{{ config.CFG_VERSION }}<br />
+      {{ _("Maintained by") }} <a class="footer" href="mailto:{{ config.CFG_SITE_SUPPORT_EMAIL }}">
+        {{- config.CFG_SITE_SUPPORT_EMAIL -}}
+      </a><br/>
+  {%- if lastupdated -%}
       {{ _("Last updated") }}: {{ lastupdated|invenio_format_date }}
-  {% endif %}
+  {%- endif -%}
+{%- endblock footer_credits %}
+    </div>
+    <div class="col-md-6">
+{%- block footer_languages %}
+      <p class="langs">
+  {%- if config.CFG_LANGUAGE_LIST_LONG -%}
+        {{ _("This site is also available in the following languages:") }} <br />
+    {%- for (lang, lang_namelong) in config.CFG_LANGUAGE_LIST_LONG %}
+        &nbsp;
+      {%- if lang != g.ln -%}
+      <a href="?ln={{ lang }}" class="langinfo" hreflang="{{ lang }}">{{ lang_namelong }}</a>
+      {%- else -%}
+        {{ lang_namelong }}
+      {%- endif %}
+    {%- endfor %}
+  {%- endif -%}
+      </p>
+{%- endblock footer_languages %}
+    </div>
   </div>
-  <div class="col-md-6">
-    <p style="text-align: right">
-      {% if config.CFG_LANGUAGE_LIST_LONG %}
-          {{ _("This site is also available in the following languages:") }} <br />
-          {% for (lang, lang_namelong) in config.CFG_LANGUAGE_LIST_LONG %}
-              &nbsp; <a href="?ln={{ lang }}" class="langinfo">{{ lang_namelong|safe }}</a>
-          {% endfor %}
-      {% endif %}
-    </p>
-  </div>
-  </div>
-  <!-- replaced page footer -->
-</div> <!-- containter -->
+</div>
+{%- endblock footer -%}

--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -135,7 +135,7 @@
 {%- block page_footer %}
     <div id="push"></div>
   </div>{# end wrap #}
-<footer>
+<footer id="footer">
   <div class="container">
     {% block pagefooteradd %}{{ pagefooteradd|safe }}{% endblock pagefooteradd %}
   </div>


### PR DESCRIPTION
- Removing styles on the `<footer>`. It's a generic element that may be used at more than one place, like `<p>` or `<address>`.
  See: http://www.whatwg.org/specs/web-apps/current-work/#the-footer-element
- Adding blocks in the footer template so one can reuse the content without having to keep the outter structure.
- Removing inline style.
- `url_for('')` -> `url_for('search.index')`

Usage sample:
- https://github.com/greut/cds-demosite/blob/309f9db351dbc0003955d620b57893670b851fbf/cds/base/templates/footer.html
- redefining it from scratch should still work as expected: https://github.com/inspirehep/inspire-next/blob/new-templates/inspire/base/templates/footer.html

Ping @giokokos for review and comments.
