### PR TITLE
assets: error logging if binary are missing

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -159,6 +159,15 @@ the following commands.
     (invenio)$ inveniomanage config set CFG_DATABASE_USER $BRANCH
     (invenio)$ inveniomanage config set CFG_SITE_URL http://0.0.0.0:4000
 
+Assets in non-development mode may be combined and minified using various
+filters (see :ref:`ext_assets`). We need to set the path to the binaries if
+they are not in the environment ``$PATH`` already.
+
+.. code-block:: console
+
+    (invenio)$ inveniomanage config set LESS_BIN `find $PWD/node_modules -iname lessc | head -1`
+    (invenio)$ inveniomanage config set CLEANCSS_BIN `find $PWD/node_modules -iname cleancss | head -1`
+
 Invenio comes with default demo site configuration examples that you can use
 for quick start.
 

--- a/docs/ext/assets.rst
+++ b/docs/ext/assets.rst
@@ -1,3 +1,5 @@
+.. _ext_assets:
+
 Assets
 ======
 

--- a/invenio/ext/assets/__init__.py
+++ b/invenio/ext/assets/__init__.py
@@ -83,9 +83,26 @@ Environment.resolver_class = InvenioResolver
 
 def setup_app(app):
     """Initialize Assets extension."""
+    app.config.setdefault("LESS_RUN_IN_DEBUG", False)
     assets = Environment(app)
     assets.url = app.static_url_path + "/"
     assets.directory = app.static_folder
+
+    commands = (("LESS_BIN", "lessc"),
+                ("CLEANCSS_BIN", "cleancss"))
+    import subprocess
+    for key, cmd in commands:
+        try:
+            command = app.config.get(key, cmd)
+            subprocess.call([command, "--version"],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+        except OSError:
+            app.logger.error("Executable `{0}` was not found. You can specify "
+                             "it via {1}."
+                             .format(cmd, key))
+            app.config["ASSETS_DEBUG"] = True
+            assets.debug = True
 
     def _jinja2_new_bundle(tag, collection, name=None, filters=None):
         if len(collection):


### PR DESCRIPTION
- Adding a check for LESS_BIN and CLEANCSS_BIN presence at startup.
  It switches to ASSETS_DEBUG=True if you ignore the error message.

ping @egabancho
