### PR TITLE
base: absolute icon font path

### DIFF
--- a/invenio/base/static/less/base.less
+++ b/invenio/base/static/less/base.less
@@ -1,5 +1,6 @@
 @import "bootstrap/bootstrap.less";
 @import "font-awesome/font-awesome.less";
+@icon-font-path: "/fonts/";
 
 body {
 	padding-top: 70px;


### PR DESCRIPTION
- Forcing the font path to be absolute. Otherwise less.js is confused, the problem doesn't occur when the stylesheet it compiled though.

Fixes #272
